### PR TITLE
Add support for API Debug Probe

### DIFF
--- a/stable/dynamic-gateway-service/Chart.yaml
+++ b/stable/dynamic-gateway-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying IBM API Connect gateway to Kubernetes
 name: dynamic-gateway-service
-version: 1.0.17
+version: 1.0.18

--- a/stable/dynamic-gateway-service/README.md
+++ b/stable/dynamic-gateway-service/README.md
@@ -33,43 +33,48 @@ The helm chart has the following Values that can be overridden using the install
 
 `helm install --set datapower.image.repository=<myimage> stable/dynamic-gateway-service`
 
-| Value                                                           | Description                                        | Default               |
-|-----------------------------------------------------------------|----------------------------------------------------|-----------------------|
-| `datapower.replicaCount`                                        | The replicaCount for the StatefulSet               | 3                     |
-| `datapower.image.repository`                                    | The image to use for this deployment               | ibmcom/datapower      |
-| `datapower.image.tag`                                           | The image tag to use for this deployment           | 2018.4.1              |
-| `datapower.image.pullPolicy`                                    | Determines when the image should be pulled         | IfNotPresent          |
-| `datapower.env.workerThreads`                                   | Number of DataPower worker threads                 |                       |
-| `datapower.resources.limits.cpu`                                | Container CPU limit                                | 8                     |
-| `datapower.resources.limits.memory`                             | Container memory limit                             | 8Gi                   |
-| `datapower.resources.requests.cpu`                              | Container CPU requested                            | 8                     |
-| `datapower.resources.requests.memory`                           | Container Memory requested                         | 8Gi                   |
-| `datapower.apicGatewayTLSSecret`                                | REQUIRED: crypto material for API Connect gateway  | N/A (required)        |
-| `datapower.gatewayPeeringLocalPort`                             | Port for gateway peering server                    | 16380                 |
-| `datapower.gatewayPeeringMonitorPort`                           | Port for gateway peering monitor                   | 26380                 |
-| `datapower.apicGatewayServiceLocalPort`                         | Port for API Connect Gateway Service               | 3000                  |
-| `datapower.apiGatewayLocalPort`                                 | Port for API Gateway                               | 9443                  |
-| `datapower.webGuiManagementState`                               | WebGUI Management admin state                      | disabled              |
-| `datapower.webGuiManagementPort`                                | WebGUI Management port                             | 9090                  |
-| `datapower.gatewaySshState`                                     | SSH admin state                                    | disabled              |
-| `datapower.gatewaySshPort`                                      | SSH Port                                           | 9022                  |
-| `datapower.restManagementState`                                 | REST Management admin state                        | disabled              |
-| `datapower.restManagementPort`                                  | REST Management port                               | 5554                  |
-| `datapower.xmlManagementLocalPort`                              | XML Management port                                | 5550                  |
-| `datapower.snmpState`                                           | SNMP Service State(used for Prometheus monitoring) | enabled               |
-| `datapower.snmpPort`                                            | SNMP Service Port(used for Prometheus monitoring)  | 1161                  |
-| `datapower.storage.tmsPeering.accessModes`                      | Access Modes for the Token Management Service Disk | [ReadWriteOnce]       |
-| `datapower.storage.tmsPeering.resources.requests.storage`       | Size for the Token Management Service Disk         | 10Gi                  |
-| `service.type`                                                  | Service type                                       | ClusterIP             |
-| `ingressType`                                                   | Type of ingress controller                         | ingress               |
-| `ingress.gateway.enabled`                                       | API gateway ingress enabled                        | true                  |
-| `ingress.gateway.enableTLS`                                     | API gateway ingress TLS enabled                    | false                 |
-| `ingress.gateway.hosts.name`                                    | API gateway ingress host matches                   | [gateway.example.com] |
-| `ingress.gateway.annotations`                                   | API gateway ingress annotations                    | []                    |
-| `ingress.gwd.enabled`                                           | APIC gateway service ingress enabled               | true                  |
-| `ingress.gwd.enableTLS`                                         | APIC gateway service ingress TLS enabled           | false                 |
-| `ingress.gwd.hosts.name`                                        | APIC gateway service ingress host matches          | [gwd.example.com]     |
-| `ingress.gwd.annotations`                                       | APIC gateway service ingress annotations           | []                    |
+| Value                                                           | Description                                              | Default               |
+|-----------------------------------------------------------------|----------------------------------------------------------|-----------------------|
+| `datapower.replicaCount`                                        | The replicaCount for the StatefulSet                     | 3                     |
+| `datapower.image.repository`                                    | The image to use for this deployment                     | ibmcom/datapower      |
+| `datapower.image.tag`                                           | The image tag to use for this deployment                 | 2018.4.1              |
+| `datapower.image.pullPolicy`                                    | Determines when the image should be pulled               | IfNotPresent          |
+| `datapower.env.workerThreads`                                   | Number of DataPower worker threads                       |                       |
+| `datapower.resources.limits.cpu`                                | Container CPU limit                                      | 8                     |
+| `datapower.resources.limits.memory`                             | Container memory limit                                   | 8Gi                   |
+| `datapower.resources.requests.cpu`                              | Container CPU requested                                  | 8                     |
+| `datapower.resources.requests.memory`                           | Container Memory requested                               | 8Gi                   |
+| `datapower.apicGatewayTLSSecret`                                | REQUIRED: crypto material for API Connect gateway        | N/A (required)        |
+| `datapower.gatewayPeeringLocalPort`                             | Port for gateway peering server                          | 16380                 |
+| `datapower.gatewayPeeringMonitorPort`                           | Port for gateway peering monitor                         | 26380                 |
+| `datapower.apicGatewayServiceLocalPort`                         | Port for API Connect Gateway Service                     | 3000                  |
+| `datapower.apiGatewayLocalPort`                                 | Port for API Gateway                                     | 9443                  |
+| `datapower.apiDebugProbe`                                       | Whether to enable API Debug Probe                        | disabled              |
+| `datapower.apiDebugProbeMaxRecords`                             | Maximum number of API Debug Probe records to keep        | 1000                  |
+| `datapower.apiDebugProbeExpiration`                             | Number of minutes before API Debug Probe records expire  | 60                    |
+| `datapower.apiDebugProbePeeringLocalPort`                       | Port for API Debug Probe peering server                  | 16382                 |
+| `datapower.apiDebugProbePeeringMonitorPort`                     | Port for API Debug Probe peering monitor                 | 26382                 |
+| `datapower.webGuiManagementState`                               | WebGUI Management admin state                            | disabled              |
+| `datapower.webGuiManagementPort`                                | WebGUI Management port                                   | 9090                  |
+| `datapower.gatewaySshState`                                     | SSH admin state                                          | disabled              |
+| `datapower.gatewaySshPort`                                      | SSH Port                                                 | 9022                  |
+| `datapower.restManagementState`                                 | REST Management admin state                              | disabled              |
+| `datapower.restManagementPort`                                  | REST Management port                                     | 5554                  |
+| `datapower.xmlManagementLocalPort`                              | XML Management port                                      | 5550                  |
+| `datapower.snmpState`                                           | SNMP Service State(used for Prometheus monitoring)       | enabled               |
+| `datapower.snmpPort`                                            | SNMP Service Port(used for Prometheus monitoring)        | 1161                  |
+| `datapower.storage.tmsPeering.accessModes`                      | Access Modes for the Token Management Service Disk       | [ReadWriteOnce]       |
+| `datapower.storage.tmsPeering.resources.requests.storage`       | Size for the Token Management Service Disk               | 10Gi                  |
+| `service.type`                                                  | Service type                                             | ClusterIP             |
+| `ingressType`                                                   | Type of ingress controller                               | ingress               |
+| `ingress.gateway.enabled`                                       | API gateway ingress enabled                              | true                  |
+| `ingress.gateway.enableTLS`                                     | API gateway ingress TLS enabled                          | false                 |
+| `ingress.gateway.hosts.name`                                    | API gateway ingress host matches                         | [gateway.example.com] |
+| `ingress.gateway.annotations`                                   | API gateway ingress annotations                          | []                    |
+| `ingress.gwd.enabled`                                           | APIC gateway service ingress enabled                     | true                  |
+| `ingress.gwd.enableTLS`                                         | APIC gateway service ingress TLS enabled                 | false                 |
+| `ingress.gwd.hosts.name`                                        | APIC gateway service ingress host matches                | [gwd.example.com]     |
+| `ingress.gwd.annotations`                                       | APIC gateway service ingress annotations                 | []                    |
 
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/stable/dynamic-gateway-service/static/gateway-peering.js
+++ b/stable/dynamic-gateway-service/static/gateway-peering.js
@@ -27,6 +27,7 @@ const APICONNECT_K8S_PEERS_SVC_FQDN = process.env.APICONNECT_K8S_PEERS_SVC_FQDN 
 const APICONNECT_DATAPOWER_DOMAIN   = process.env.APICONNECT_DATAPOWER_DOMAIN || 'apiconnect';
 const APICONNECT_V5_COMPAT_MODE     = process.env.APICONNECT_V5_COMPAT_MODE || 'on';
 const APICONNECT_ENABLE_TMS         = process.env.APICONNECT_ENABLE_TMS || 'off';
+const APICONNECT_API_DEBUG_PROBE    = process.env.APICONNECT_API_DEBUG_PROBE || 'off';
 
 const GATEWAY_PEERING_CONFIG_NAME   = process.env.GATEWAY_PEERING_CONFIG_NAME || 'gwd';
 const GATEWAY_PEERING_LOCAL_ADDRESS = process.env.GATEWAY_PEERING_LOCAL_ADDRESS || 'eth0_ipv4_1';
@@ -43,6 +44,14 @@ const TMS_PEERING_MONITOR_PORT      = process.env.TMS_PEERING_MONITOR_PORT || '2
 const TMS_PEERING_ENABLE_SSL        = process.env.TMS_PEERING_ENABLE_SSL ? process.env.TMS_PEERING_ENABLE_SSL !== 'off' : GATEWAY_PEERING_ENABLE_SSL;
 const TMS_PEERING_SSL_KEY           = process.env.TMS_PEERING_SSL_KEY || 'tms_key';
 const TMS_PEERING_SSL_CERT          = process.env.TMS_PEERING_SSL_CERT || 'tms_cert';
+
+const ADP_PEERING_CONFIG_NAME       = process.env.ADP_PEERING_CONFIG_NAME || 'api-probe';
+const ADP_PEERING_LOCAL_ADDRESS     = process.env.ADP_PEERING_LOCAL_ADDRESS || 'eth0_ipv4_1';
+const ADP_PEERING_LOCAL_PORT        = process.env.ADP_PEERING_LOCAL_PORT || '15382';
+const ADP_PEERING_MONITOR_PORT      = process.env.ADP_PEERING_MONITOR_PORT || '25382';
+const ADP_PEERING_ENABLE_SSL        = process.env.ADP_PEERING_ENABLE_SSL ? process.env.ADP_PEERING_ENABLE_SSL !== 'off' : GATEWAY_PEERING_ENABLE_SSL;
+const ADP_PEERING_SSL_KEY           = process.env.ADP_PEERING_SSL_KEY || 'api_probe_key';
+const ADP_PEERING_SSL_CERT          = process.env.ADP_PEERING_SSL_CERT || 'api_probe_cert';
 
 const PEERING_LOG_LEVEL             = process.env.PEERING_LOG_LEVEL || 'internal';
 
@@ -184,6 +193,24 @@ exit
 
       await writeFile(tmsConfigPath, tmsConfig);
       log(`Generated ${tmsConfigPath}\n${tmsConfig}`);
+    }
+
+    if (APICONNECT_API_DEBUG_PROBE === 'enabled') {
+      let adpConfig = generateGatewayPeeringConfig({
+        name: ADP_PEERING_CONFIG_NAME,
+        localAddress: ADP_PEERING_LOCAL_ADDRESS,
+        localPort: ADP_PEERING_LOCAL_PORT,
+        monitorPort: ADP_PEERING_MONITOR_PORT,
+        priority: priority,
+        peers: peers,
+        enableSSL: ADP_PEERING_ENABLE_SSL,
+        sslKey: ADP_PEERING_SSL_KEY,
+        sslCert: ADP_PEERING_SSL_CERT
+      });
+
+      let adpConfigPath = `/drouter/config/${APICONNECT_DATAPOWER_DOMAIN}/api-probe-peering.cfg`;
+      await writeFile(adpConfigPath, adpConfig);
+      log(`Generated ${adpConfigPath}\n${adpConfig}`);
     }
 
     if (ordinal > 0) {

--- a/stable/dynamic-gateway-service/templates/service.yaml
+++ b/stable/dynamic-gateway-service/templates/service.yaml
@@ -30,6 +30,16 @@ spec:
       protocol: TCP
       name: tms-monit-port
 {{- end }}
+{{- if eq (.Values.datapower.apiDebugProbe | default "disabled") "enabled" }}
+    - port: {{ .Values.datapower.apiDebugProbePeeringLocalPort }}
+      targetPort: {{ .Values.datapower.apiDebugProbePeeringLocalPort }}
+      protocol: TCP
+      name: adp-local-port
+    - port: {{ .Values.datapower.apiDebugProbePeeringMonitorPort }}
+      targetPort: {{ .Values.datapower.apiDebugProbePeeringMonitorPort }}
+      protocol: TCP
+      name: adp-monit-port
+{{- end }}
   clusterIP: None
   publishNotReadyAddresses: true
   selector:

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -138,6 +138,13 @@ spec:
 {{- else }}
               value: "off"
 {{- end }}
+            - name: APICONNECT_API_DEBUG_PROBE
+{{/* Enforce valid values for apiDebugProbe as 'enabled' and 'disabled' (default: 'disabled') */}}
+{{- if eq (.Values.datapower.apiDebugProbe | default "disabled") "enabled" }}
+              value: "enabled"
+{{- else }}
+              value: "disabled"
+{{- end }}
             - name: GATEWAY_PEERING_MONITOR_PORT
               value: {{ .Values.datapower.gatewayPeeringMonitorPort | quote }}
             - name: GATEWAY_PEERING_LOCAL_PORT
@@ -150,6 +157,12 @@ spec:
               value: {{ .Values.datapower.tmsPeeringLocalPort | quote }}
             - name: TMS_PEERING_ENABLE_SSL
               value: {{ .Values.datapower.env.tmsPeeringEnableSSL | quote }}
+            - name: ADP_PEERING_MONITOR_PORT
+              value: {{ .Values.datapower.apiDebugProbePeeringMonitorPort | quote }}
+            - name: ADP_PEERING_LOCAL_PORT
+              value: {{ .Values.datapower.apiDebugProbePeeringLocalPort | quote }}
+            - name: ADP_PEERING_ENABLE_SSL
+              value: {{ .Values.datapower.env.apiDebugProbePeeringEnableSSL | quote }}
 {{- if .Values.datapower.env.workerThreads }}
 {{- if gt .Values.datapower.env.workerThreads 0.0 }}
             - name: DATAPOWER_WORKER_THREADS
@@ -177,6 +190,10 @@ spec:
               name: tms-local-port
             - containerPort: {{ .Values.datapower.tmsPeeringMonitorPort }}
               name: tms-monit-port
+            - containerPort: {{ .Values.datapower.apiDebugProbePeeringLocalPort }}
+              name: adp-local-port
+            - containerPort: {{ .Values.datapower.apiDebugProbePeeringMonitorPort }}
+              name: adp-monit-port
             - containerPort: {{ .Values.datapower.apicGatewayServiceLocalPort }}
               name: apic-gw-mgmt
             - containerPort: {{ .Values.datapower.apiGatewayLocalPort }}

--- a/stable/dynamic-gateway-service/values.yaml
+++ b/stable/dynamic-gateway-service/values.yaml
@@ -24,6 +24,8 @@ datapower:
     # Should be on or off
     peeringEnableSSL: "on"
     # Should be on or off
+    apiDebugProbePeeringEnableSSL: "on"
+    # Should be on or off
     tmsPeeringEnableSSL: "on"
     # Should be on or off
     enableTMS: "off"
@@ -64,6 +66,13 @@ datapower:
   apicGatewayServiceLocalPort: 3000
   apicGatewayServiceLocalAddress: 0.0.0.0
   apicGatewayServiceTLSSecret:
+  # This value should either be 'enabled' or 'disabled'. Default is disabled
+  apiDebugProbe: "disabled"
+  apiDebugProbeMaxRecords: 1000
+  # api-debugprobe expiration in minutes
+  apiDebugProbeExpiration: 60
+  apiDebugProbePeeringLocalPort: 16382
+  apiDebugProbePeeringMonitorPort: 26382
   # This value should either be 'on' or 'off'. Default is 'on'
   apicGatewayServiceV5CompatibilityMode: "on"
   apiGatewayLocalAddress: 0.0.0.0


### PR DESCRIPTION
* Add apiDebugProbe options to values.yml

* Dynamically configure API Debug Probe peering via gateway-peering.js

* Implicitly enable rest-mgmt when apiDebugProbe enabled

* Import peering and set api-debugprobe in domain config template

* Expose peering ports on container and add to internal service

* Update README with API Debug Probe options

* Bump chart version