### PR TITLE
support zone level pod anti-affinity

### DIFF
--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -38,6 +38,9 @@ spec:
       {{- end }}
       {{- end }}
       affinity:
+{{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -47,6 +50,7 @@ spec:
                 matchLabels:
                   app: {{ template "dynamic-gateway-service.name" . }}
                   release: {{ .Release.Name }}
+{{- end }}
       initContainers:
         - name: dpinit
           image: "{{ .Values.datapower.busybox.repository }}:{{ .Values.datapower.busybox.tag }}"


### PR DESCRIPTION
- Added support for zone-level podAntiAffinity in an multi-zone-region IKS cluster. 
- gateway deployment chart can override the affinity by specifying for example:
```
affinity:
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      - topologyKey: "failure-domain.beta.kubernetes.io/zone"
        labelSelector:
          matchLabels:
            app: dynamic-gateway-service
```
- Helm template updates in this PR to use the above properties.