### PR TITLE
support zone level pod anti-affinity

### DIFF
--- a/stable/dynamic-gateway-service/Chart.yaml
+++ b/stable/dynamic-gateway-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying IBM API Connect gateway to Kubernetes
 name: dynamic-gateway-service
-version: 1.0.18
+version: 1.0.19

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
         runAsNonRoot: false
         runAsUser: 0
       affinity:
+{{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -53,6 +56,7 @@ spec:
                 matchLabels:
                   app: {{ template "dynamic-gateway-service.name" . }}
                   release: {{ .Release.Name }}
+{{- end }}
       initContainers:
         - name: dpinit
           image: "{{ .Values.datapower.busybox.repository }}:{{ .Values.datapower.busybox.tag }}"


### PR DESCRIPTION
- Added support for zone-level podAntiAffinity in an multi-zone-region IKS cluster. 
- gateway deployment chart can override the affinity by specifying for example:
```
affinity:
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      - topologyKey: "failure-domain.beta.kubernetes.io/zone"
        labelSelector:
          matchLabels:
            app: dynamic-gateway-service
```
- Helm template updates in this PR to use the above properties.
