### PR TITLE
Raise permissions when SSH is enabled

### DIFF
--- a/stable/dynamic-gateway-service/Chart.yaml
+++ b/stable/dynamic-gateway-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying IBM API Connect gateway to Kubernetes
 name: dynamic-gateway-service
-version: 1.0.21
+version: 1.0.22

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -104,11 +104,24 @@ spec:
             privileged: false
             readOnlyRootFilesystem: false
             allowPrivilegeEscalation: false
+# Dynamically increase the user permissions of the DataPower container when SSH is enabled.
+{{- if eq .Values.datapower.gatewaySshState "enabled" }}
+            runAsNonRoot: false
+            runAsUser: 0
+{{- else }}
             runAsNonRoot: true
             runAsUser: 101
+{{- end }}
             capabilities:
               drop:
               - ALL
+# Add capabilities needed for SSH only when SSH is enabled
+{{- if eq .Values.datapower.gatewaySshState "enabled" }}
+              add:
+              - SETGID
+              - SETUID
+              - SYS_CHROOT
+{{- end }}
           command:
             - sh
             - -c


### PR DESCRIPTION
SSH requires root permissions in pod containers to work properly. This change adds switching to keep permissions low when users do not require SSH.