### PR TITLE
Add ILMT annotations and license control

### DIFF
--- a/stable/dynamic-gateway-service/Chart.yaml
+++ b/stable/dynamic-gateway-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying IBM API Connect gateway to Kubernetes
 name: dynamic-gateway-service
-version: 1.0.23
+version: 1.0.24

--- a/stable/dynamic-gateway-service/README.md
+++ b/stable/dynamic-gateway-service/README.md
@@ -35,6 +35,7 @@ The helm chart has the following Values that can be overridden using the install
 
 | Value                                                           | Description                                              | Default               |
 |-----------------------------------------------------------------|----------------------------------------------------------|-----------------------|
+| `datapower.licenseVersion`                                      | License version of DataPower to be deployed              | N/A                   |
 | `datapower.replicaCount`                                        | The replicaCount for the StatefulSet                     | 3                     |
 | `datapower.image.repository`                                    | The image to use for this deployment                     | ibmcom/datapower      |
 | `datapower.image.tag`                                           | The image tag to use for this deployment                 | 2018.4.1              |
@@ -63,6 +64,7 @@ The helm chart has the following Values that can be overridden using the install
 | `datapower.xmlManagementLocalPort`                              | XML Management port                                      | 5550                  |
 | `datapower.snmpState`                                           | SNMP Service State(used for Prometheus monitoring)       | enabled               |
 | `datapower.snmpPort`                                            | SNMP Service Port(used for Prometheus monitoring)        | 1161                  |
+| `datapower.flexpointBundle`                                     | Flexpoint Bundle type for ILMT scanning                  | N/A                   |
 | `datapower.storage.tmsPeering.accessModes`                      | Access Modes for the Token Management Service Disk       | [ReadWriteOnce]       |
 | `datapower.storage.tmsPeering.resources.requests.storage`       | Size for the Token Management Service Disk               | 10Gi                  |
 | `service.type`                                                  | Service type                                             | ClusterIP             |

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -27,6 +27,25 @@ spec:
         prometheus.io/port: '63512'
         prometheus.io/target: '127.0.0.1:{{ .Values.datapower.snmpPort }}'
         prometheus.io/module: 'dpStatusMIB'
+{{- with .Values.datapower }}
+{{- if .licenseVersion }}
+{{- if or (eq .licenseVersion "Production") (eq .licenseVersion "Nonproduction") (eq .licenseVersion "Developers") }}
+        productFlexpointBundle: "{{ .flexpointBundle }}"
+        productMetric: "PROCESSOR_VALUE_UNIT"
+        productVersion: "{{ .image.tag }}"
+  {{- if eq .licenseVersion "Production" }}
+        productID: '887a7b80dd7b40c9b978ff085230604e'
+        productChargedContainers: "all"
+  {{- else if eq .licenseVersion "Nonproduction" }}
+        productID: 'bd624448e8484592879f2e1a950686bd'
+        productChargedContainers: "all"
+  {{- else }}
+        productID: 'IBMDataPowerGatewayVirtualEdition_{{ .image.tag }}_Developers'
+        productChargedContainers: ""
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
       labels:
         app: {{ template "dynamic-gateway-service.name" . }}
         release: {{ .Release.Name }}
@@ -126,10 +145,24 @@ spec:
             - sh
             - -c
             - |
+{{- with .Values.datapower }}
+{{- if .licenseVersion }}
+{{- if or (eq .licenseVersion "Production") (eq .licenseVersion "Nonproduction") (eq .licenseVersion "Developers") }}
               set -x
               export $(env | grep ^DATAPOWER_ | cut -d= -f1)
               /root/node /start/gateway-peering.js
-              exec /start.sh --log-format {{ .Values.datapower.env.defaultLogFormat }}
+              exec /start.sh --log-format {{ .env.defaultLogFormat }}
+{{- else }}
+              echo "ERROR: USER MUST SPECIFY A LICENSE VERSION"
+              echo "Please set datapower.licenseVersion"
+              exit 1
+{{- end }}
+{{- else }}
+              echo "ERROR: USER MUST SPECIFY A LICENSE VERSION"
+              echo "Please set datapower.licenseVersion"
+              exit 1
+{{- end }}
+{{- end }}
           stdin: true
           tty: true
           env:

--- a/stable/dynamic-gateway-service/values.yaml
+++ b/stable/dynamic-gateway-service/values.yaml
@@ -6,6 +6,9 @@
 # gateway section
 #
 datapower:
+  # License version of DataPower. MUST be included to deploy.
+  # Accepts Developers, Production, and Nonproduction.
+  licenseVersion:
   image:
     repository: ibmcom/datapower
     tag: 2018.4.1
@@ -97,6 +100,7 @@ datapower:
   snmpState: "enabled"
   snmpLocalAddress: 0.0.0.0
   snmpPort: 1161
+  flexpointBundle:
   storage:
     tmsPeering:
       accessModes:


### PR DESCRIPTION
Adds a new required licenseVersion value. Users now must affirmatively declare what license version of DataPower they are deploying with the dynamic-gateway-service chart. If the licenseVersion variable is not set or is not "Developers", "Production", or "Nonproduction", then the pods will fail to deploy with an error in kubectl logs stating that the licenseVersion must be specified.