### PR TITLE
Add permissions override capability to root

### DIFF
--- a/stable/dynamic-gateway-service/Chart.yaml
+++ b/stable/dynamic-gateway-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying IBM API Connect gateway to Kubernetes
 name: dynamic-gateway-service
-version: 1.0.26
+version: 1.0.27

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -172,6 +172,7 @@ spec:
               - SETGID
               - SETUID
               - SYS_CHROOT
+              - DAC_OVERRIDE
 {{- end }}
           command:
             - sh


### PR DESCRIPTION
The gateway instance has been hitting an occasional issue where some directories are still owned by the `drouter` user. When running as `root` with limited capabilities, the gateway process was not able to access those directories owned by `drouter`. This fixes that.