### PR TITLE
All domain config, local, certs

### DIFF
--- a/stable/dynamic-gateway-service/README.md
+++ b/stable/dynamic-gateway-service/README.md
@@ -65,6 +65,9 @@ The helm chart has the following Values that can be overridden using the install
 | `datapower.snmpState`                                           | SNMP Service State(used for Prometheus monitoring)       | enabled               |
 | `datapower.snmpPort`                                            | SNMP Service Port(used for Prometheus monitoring)        | 1161                  |
 | `datapower.flexpointBundle`                                     | Flexpoint Bundle type for ILMT scanning                  | N/A                   |
+| `datapower.additionalConfig`                                    | List of domains and config files                         |                       |
+| `datapower.additionalLocalTar`                                  | Path to local directory tar file                         |                       |
+| `datapower.additionalCerts`                                     | List of domains and cert secrets                         |                       |
 | `datapower.storage.tmsPeering.accessModes`                      | Access Modes for the Token Management Service Disk       | [ReadWriteOnce]       |
 | `datapower.storage.tmsPeering.resources.requests.storage`       | Size for the Token Management Service Disk               | 10Gi                  |
 | `datapower.customDatapowerConfig`                               | Name of ConfigMap with one or more DataPower .cfg files  |                       |
@@ -85,6 +88,39 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 ```bash
 $ helm install --name my-release -f values.yaml stable/dynamic-gateway-service
 ```
+
+
+### Adding new config
+New DataPower configuration can be added into the gateway by use of the `datapower.additionalConfig` value. This value takes the form of a list of domain-config pairs, like so:
+```
+datapower:
+  additionalConfig:
+  - domain: "default"
+    config: "config/default.cfg
+  - domain: "apiconnect"
+    config: "config/apiconnect.cfg"
+```
+The paths to config files must be inside the chart directory. These config files should be standard DataPower CLI config.
+
+### Adding local files
+Local files can be added into the gateway deployment by use of the `datapower.additionalLocalTar` value. This value is a path to a tar file which contains all the files you wish to add. This tar file should be a well formatted DataPower `local:` directory where files intended for the `default` domain are on the top level and all files intended for a different domain are in a subdirectory named for that domain.
+
+### Adding certificates
+Certificates and other crypto files can be added to the `cert:` directory by use of the `datapower.additionalCerts` value. This value takes the form of a list of domain-secret pairs, like so:
+```
+datapower:
+  additionalCerts:
+  - domain: "default"
+    secret: "some-default-cert-secret"
+  - domain: "apiconnect"
+    secret: "some-apiconnect-cert-secret"
+```
+The secrets are Kubernetes secrets which contain the crypto files you wish to use. To create the secret from an existing crypto key-cert pair:
+```
+kubectl create secret generic my-secret --from-file=/path/to/key.pem --from-file=/path/to/cert.pem
+```
+
+
 
 [View the official IBM DataPower Gateway for Developers Docker Image in Docker Hub](https://hub.docker.com/r/ibmcom/datapower/)
 

--- a/stable/dynamic-gateway-service/static/additional-cert-handler.sh
+++ b/stable/dynamic-gateway-service/static/additional-cert-handler.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+###############################################################################
+# additional-cert-handler.sh
+#
+# This script moves the added certs from their volume mounted locations into
+# the correct domain in /root/secure/usrcerts/
+#
+###############################################################################
+
+INITCERTS="/init/certs"
+
+for domain in $(ls $INITCERTS)
+do
+  for secret in $(ls $INITCERTS/$domain)
+  do
+    # default domain is top level
+    if [ "$domain" == "default" ]
+    then
+      cp -rL $INITCERTS/$domain/$secret/* /root/secure/usrcerts/
+      continue
+    fi
+    if [ ! -d "/root/secure/usrcerts/$domain" ]
+    then
+      mkdir /root/secure/usrcerts/$domain
+    fi
+    cp -rL $INITCERTS/$domain/$secret/* /root/secure/usrcerts/$domain/
+  done
+done
+

--- a/stable/dynamic-gateway-service/static/custom-config-handler.sh
+++ b/stable/dynamic-gateway-service/static/custom-config-handler.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+###############################################################################
+# This script handles the logic behind dealing with the custom configuration
+# specified in .Values.datapower.additionalConfig.
+#
+# All configuration files should be in the format <domain>.cfg in the directory
+# /init/custom-config/
+#
+# This script will loop over the files in that directory and append the contents
+# of each file into the existing configuration file for the applicable domain
+# or create a new domain if one does not already exist.
+###############################################################################
+
+
+# Loop over all files in /init/additional-config/
+for configfile in /init/additional-config/*
+do
+  # Get domain name by stripping path and extension
+  domain="$(echo $configfile | sed -e 's|/init/additional-config/||g' -e 's|.cfg||g')"
+
+  # Check for default domain, which is a special case
+  if [ "$domain" == "default" ]
+  then
+    # default domain is defined in auto-startup.cfg
+    cat $configfile >> /drouter/config/auto-startup.cfg
+    # No further action needed for default domain
+    continue
+  fi
+
+  # Check for existence of domain
+  if [ -e "/drouter/config/$domain/$domain.cfg" ]
+  then
+    # Append new configuration into existing domain
+    cat $configfile >> /drouter/config/$domain/$domain.cfg
+    # No further action needed
+    continue
+  fi
+
+  # Domain does not exist, so create it
+  mkdir /drouter/config/$domain
+  echo "top; configuration;" > /drouter/config/$domain/$domain.cfg
+  cat $configfile >> /drouter/config/$domain/$domain.cfg
+
+  # Append config execution to default domain
+  (
+  cat <<EOF
+
+domain $domain
+  visible-domain default
+exit
+
+%if% available "include-config"
+
+include-config "$domain-cfg"
+  config-url "config:///$domain/$domain.cfg"
+  auto-execute
+  no interface-detection
+exit
+
+exec "config:///$domain/$domain.cfg"
+
+%endif%
+EOF
+  ) >> /drouter/config/auto-startup.cfg
+
+done
+

--- a/stable/dynamic-gateway-service/static/unpack-local-files.sh
+++ b/stable/dynamic-gateway-service/static/unpack-local-files.sh
@@ -1,0 +1,31 @@
+#/bin/sh
+###############################################################################
+# unpack-local-files.sh
+#
+# This script takes the packed local files and unpacks them into the drouter
+# local: directory. The expectation is that the tar file contains a proper
+# DataPower directory structure for domains, where files in the top level
+# are intended for the default domain and files intended for other domains
+# are contained in subdirectories like /drouter/local/apiconnect/
+#
+###############################################################################
+
+
+# Create extraction directory
+mkdir local-extract
+cd local-extract
+
+# Decode tar
+base64 -d /init/additional-local/* > local.tar
+
+# extract
+tar xf local.tar
+
+# If top level is local, move into local
+if ls | grep -q 'local/'
+then
+  cd local/
+fi
+
+# Copy all files over to local path
+cp -r * /drouter/local/

--- a/stable/dynamic-gateway-service/templates/configmaps-custom-config.yaml
+++ b/stable/dynamic-gateway-service/templates/configmaps-custom-config.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.datapower.additionalConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dynamic-gateway-service.fullname" . }}-custom-config
+data:
+{{- range .Values.datapower.additionalConfig }}
+  {{ .domain }}.cfg: |
+{{ $.Files.Get .configFile | indent 4 -}}
+{{- end }}
+{{- end }}

--- a/stable/dynamic-gateway-service/templates/configmaps-local-files.yaml
+++ b/stable/dynamic-gateway-service/templates/configmaps-local-files.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.datapower.additionalLocalTar }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dynamic-gateway-service.fullname" . }}-local-files
+data:
+  local.tar.gz: |
+{{ $.Files.Get .Values.datapower.additionalLocalTar | b64enc | indent 4 -}}
+{{- end }}

--- a/stable/dynamic-gateway-service/templates/configmaps-static-init-scripts.yaml
+++ b/stable/dynamic-gateway-service/templates/configmaps-static-init-scripts.yaml
@@ -6,4 +6,16 @@ data:
   init-admin-user.sh: |
 {{ .Files.Get "static/init-admin-user.sh" | indent 4 }}
   init-dpm-check.sh: |
-{{ .Files.Get "static/init-dpm-check.sh" | indent 4 -}}
+{{ .Files.Get "static/init-dpm-check.sh" | indent 4 }}
+{{- if .Values.datapower.additionalConfig }}
+  custom-config-handler.sh: |
+{{ .Files.Get "static/custom-config-handler.sh" | indent 4 }}
+{{- end }}
+{{- if .Values.datapower.additionalLocalTar }}
+  unpack-local-files.sh: |
+{{ .Files.Get "static/unpack-local-files.sh" | indent 4 }}
+{{- end }}
+{{- if .Values.datapower.additionalCerts }}
+  additional-cert-handler.sh: |
+{{ .Files.Get "static/additional-cert-handler.sh" | indent 4 }}
+{{- end }}

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -108,6 +108,15 @@ spec:
 {{- if .Values.datapower.adminUserSecret }}
               sh /init/scripts/init-admin-user.sh
 {{- end }}
+{{- if .Values.datapower.additionalConfig }}
+              sh /init/scripts/custom-config-handler.sh
+{{- end }}
+{{- if .Values.datapower.additionalLocalTar }}
+              sh /init/scripts/unpack-local-files.sh
+{{- end }}
+{{- if .Values.datapower.additionalCerts }}
+              sh /init/scripts/additional-cert-handler.sh
+{{- end }}
 {{- if .Values.datapower.customDatapowerConfig }}
               cat /init/custom-config/*.cfg > /drouter/config/apiconnect/custom-config.cfg
 {{- end }}
@@ -147,6 +156,24 @@ spec:
 {{- if .Values.datapower.customDatapowerConfig }}
             - name: init-custom-config-volume
               mountPath: /init/custom-config
+{{- end }}
+{{- if .Values.datapower.additionalConfig }}
+            - name: init-additional-config-volume
+              mountPath: /init/additional-config
+{{- end }}
+{{- if .Values.datapower.additionalLocalTar }}
+            - name: init-additional-local-volume
+              mountPath: /init/additional-local
+            - name: drouter-local-volume
+              mountPath: /drouter/local
+{{- end }}
+{{- if .Values.datapower.additionalCerts }}
+            - name: drouter-certs-volume
+              mountPath: /root/secure/usrcerts
+{{- range .Values.datapower.additionalCerts }}
+            - name: {{ .secret }}-volume
+              mountPath: /init/certs/{{ .domain }}/{{ .secret }}
+{{- end }}
 {{- end }}
 {{- else }}
 {{/* No initContainer if requirements are not satisfied */}}
@@ -380,6 +407,14 @@ spec:
             - name: tms
               mountPath: /drouter/ramdisk2/mnt/raid-volume/raid0/local
 {{- end }}
+{{- if .Values.datapower.additionalLocalTar }}
+            - name: drouter-local-volume
+              mountPath: /drouter/local
+{{- end }}
+{{- if .Values.datapower.additionalCerts }}
+            - name: drouter-certs-volume
+              mountPath: /root/secure/usrcerts
+{{- end }}
       volumes:
         - name: init-config-volume
           configMap:
@@ -416,6 +451,27 @@ spec:
         - name: root-secure-usrcerts-apiconnect-gwd-volume
           secret:
             secretName: {{ .Values.datapower.apicGatewayServiceTLSSecret }}
+{{- if .Values.datapower.additionalConfig }}
+        - name: init-additional-config-volume
+          configMap:
+            name: {{ template "dynamic-gateway-service.fullname" . }}-custom-config
+{{- end }}
+{{- if .Values.datapower.additionalLocalTar }}
+        - name: init-additional-local-volume
+          configMap:
+            name: {{ template "dynamic-gateway-service.fullname" . }}-local-files
+        - name: drouter-local-volume
+          emptyDir: {}
+{{- end }}
+{{- if .Values.datapower.additionalCerts }}
+{{- range .Values.datapower.additionalCerts }}
+        - name: {{ .secret }}-volume
+          secret:
+            secretName: {{ .secret }}
+{{- end }}
+        - name: drouter-certs-volume
+          emptyDir: {}
+{{- end }}
 {{- if eq (.Values.datapower.env.enableTMS | default "off") "on" }}
   volumeClaimTemplates:
   - metadata:

--- a/stable/dynamic-gateway-service/values.yaml
+++ b/stable/dynamic-gateway-service/values.yaml
@@ -119,6 +119,9 @@ datapower:
   snmpLocalAddress: 0.0.0.0
   snmpPort: 1161
   flexpointBundle:
+  additionalConfig:
+  additionalLocalTar:
+  additionalCerts:
   storage:
     tmsPeering:
       accessModes:


### PR DESCRIPTION
This pull request adds the ability to dynamically add DataPower configuration, local files, and certificates at deploy time. Users will be able to maintain their own additional config, etc. via source control without needing to modify a newly released chart.