### PR TITLE
Avoid mounting directly to /root/secure/usrcerts/apiconnect

### DIFF
--- a/stable/dynamic-gateway-service/static/usrcerts-handler.sh
+++ b/stable/dynamic-gateway-service/static/usrcerts-handler.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+###############################################################################
+# usrcerts-handler.sh
+#
+# This script moves the added certs from their volume mounted locations into
+# the correct location under /root/secure/usrcerts/apiconnect.
+# This script is used so we can avoid mounting secrets directly to `apiconnect`
+#
+###############################################################################
+
+TYPE=$1
+CERTS_DIR="/opt/ibm/datapower/init/usrcerts/${TYPE}"
+
+if [ ! -d "/root/secure/usrcerts/apiconnect/${TYPE}" ]
+then
+  mkdir "/root/secure/usrcerts/apiconnect/${TYPE}"
+fi
+cp -rL $CERTS_DIR/* "/root/secure/usrcerts/apiconnect/${TYPE}"

--- a/stable/dynamic-gateway-service/templates/configmaps-static-init-scripts.yaml
+++ b/stable/dynamic-gateway-service/templates/configmaps-static-init-scripts.yaml
@@ -23,3 +23,7 @@ data:
   apim-certs-handler.sh: |
 {{ .Files.Get "static/apim-certs-handler.sh" | indent 4 }}
 {{- end }}
+{{- if .Values.datapower.env.syslogTLSSecret }}
+  usrcerts-handler.sh: |
+{{ .Files.Get "static/usrcerts-handler.sh" | indent 4 }}
+{{- end }}

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -152,6 +152,9 @@ spec:
 {{- if .Values.datapower.additionalCerts }}
               sh /opt/ibm/datapower/init/scripts/additional-cert-handler.sh
 {{- end }}
+{{- if .Values.datapower.env.syslogTLSSecret }}
+              sh /opt/ibm/datapower/init/scripts/usrcerts-handler.sh syslog
+{{- end }}
 {{- if .Values.datapower.apimServerValidationSecret }}
               sh /opt/ibm/datapower/init/scripts/apim-certs-handler.sh server
 {{- end }}
@@ -425,8 +428,8 @@ spec:
             - name: drouter-config-volume
               mountPath: /drouter/config
 {{- if .Values.datapower.env.syslogTLSSecret }}
-            - name: root-secure-usrcerts-apiconnect-syslog-volume
-              mountPath: /root/secure/usrcerts/apiconnect/syslog
+            - name: init-usrcerts-syslog-volume
+              mountPath: /opt/ibm/datapower/init/usrcerts/syslog
 {{- end }}
 {{- if .Values.datapower.apimServerValidationSecret }}
             - name: init-apim-certs-server-volume
@@ -650,7 +653,7 @@ spec:
         - name: root-secure-usrcerts-volume
           emptyDir: {}
 {{- if .Values.datapower.env.syslogTLSSecret }}
-        - name: root-secure-usrcerts-apiconnect-syslog-volume
+        - name: init-usrcerts-syslog-volume
           secret:
             secretName: {{ .Values.datapower.env.syslogTLSSecret }}
 {{- end }}


### PR DESCRIPTION
- Mount to `/opt/ibm/datapower/init/usrcerts/<sub>`
- Copy to `/root/secure/usrcerts/apiconnect/<sub>` at startup