### PR TITLE
skip null pull secret

### DIFF
--- a/stable/dynamic-gateway-service/templates/datapower-monitor.yaml
+++ b/stable/dynamic-gateway-service/templates/datapower-monitor.yaml
@@ -77,7 +77,9 @@ spec:
       imagePullSecrets:
       {{- if .Values.datapower.image.pullSecrets }}
       {{- range .Values.datapower.image.pullSecrets }}
+      {{- if .name }}
       - name: {{ .name }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.cip }}

--- a/stable/dynamic-gateway-service/templates/registration-job.yaml
+++ b/stable/dynamic-gateway-service/templates/registration-job.yaml
@@ -10,7 +10,9 @@ spec:
       imagePullSecrets:
         {{- if .Values.datapower.image.pullSecrets }}
         {{- range .Values.datapower.image.pullSecrets }}
+        {{- if .name }}
         - name: {{ .name }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.cip }}

--- a/stable/dynamic-gateway-service/templates/statefulset.yaml
+++ b/stable/dynamic-gateway-service/templates/statefulset.yaml
@@ -62,7 +62,9 @@ spec:
       imagePullSecrets:
       {{- if .Values.datapower.image.pullSecrets }}
       {{- range .Values.datapower.image.pullSecrets }}
+      {{- if .name }}
       - name: {{ .name }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.cip }}


### PR DESCRIPTION
When doing upgrades to v2018FP15 or later the Helm upgrade may fail with a message `failed to create patch: map: map[] does not contain declared merge key` , this may happen in setups where no imagePullSecret was set and this issue is faced https://github.com/kubernetes/kubernetes/issues/98963
